### PR TITLE
Feature/landing scene upgrades

### DIFF
--- a/components/Landing.jsx
+++ b/components/Landing.jsx
@@ -5,9 +5,10 @@ import SVGText from "./svgs/SVGText";
 import Socials from "./Socials";
 import { SocialHoverContext } from "./contexts/SocialHoverContext";
 import { gsap } from 'gsap';
-import JustBlackjack from '../components/JustBlackjack'
+import JustBlackjack from '../components/JustBlackjack';
+import ParticleGraphs from './ParticleGraphs';
 
-export default function Landing() {
+export default function Landing({ particleData }) {
 
   // Create references to drive GSAP animations
   const titleRef = useRef(null);
@@ -119,14 +120,18 @@ export default function Landing() {
     <div className="landing-container" id="landing">
       <div className="title-container">
         <div className="title-contents">
-          <h1
-            className="title-text gradient-text noselect cotton-candy-gr"
-            role="heading"
-            aria-level="1"
-            ref={titleRef}
-          >
-            Darren<br/>Wong
-          </h1>
+          <div className="title-left">
+            <h1
+              className="title-text gradient-text noselect cotton-candy-gr"
+              role="heading"
+              aria-level="1"
+              ref={titleRef}
+            >
+              Darren<br/>Wong
+            </h1>
+            {/* Live particle graphs directly under name */}
+            <ParticleGraphs particleData={particleData} />
+          </div>
           <SocialHoverContext.Provider value={{ highlightedWord, setHighlightedWord }}>
             <div className="noselect landing-link-container">
               <div className="socials-container" ref={socialsRef}><Socials /></div>

--- a/components/Landing.jsx
+++ b/components/Landing.jsx
@@ -71,38 +71,19 @@ export default function Landing({ particleData }) {
 
   // Animate in landing elements
   useEffect(() => {
+    const graphsEl = document.querySelector('.graphs-boxes');
+    const headerEls = [titleRef.current, socialsRef.current, ...roleRef.current];
+    if (graphsEl) headerEls.push(graphsEl);
 
-    // Animate title
-    gsap.fromTo(
-      titleRef.current, 
-      { opacity: 0 }, 
-      { opacity: 1, duration: 3, delay: 0, ease: "power1.inOut" }
-    );
+    // Start with all invisible and pointerEvents off for socials
+    gsap.set(headerEls, { autoAlpha: 0 });
+    gsap.set(socialsRef.current, { pointerEvents: 'none' });
 
-    // Initially disable pointer events on roles
-    gsap.set(socialsRef.current, { pointerEvents: "none" });
-
-    // Animate socials
-    gsap.fromTo(
-      socialsRef.current, 
-      { opacity: 0 }, 
-      { opacity: 1, duration: 3, delay: 0, ease: "power1.inOut" },
-    );
-
-    // Animate roles with stagger
-    gsap.fromTo(
-      roleRef.current, 
-      { opacity: 0 }, 
-      { 
-        opacity: 1, duration: 0.8, 
-        delay: 2, stagger: 0.8 , 
-        ease: "power1.inOut",
-        onComplete: function() {
-          gsap.set(socialsRef.current, { pointerEvents: "auto" })
-        }
-      }
-    );
-
+    // Fade everything in simultaneously
+    gsap.to(headerEls, { autoAlpha: 1, duration: 1.5, ease: 'power1.inOut', onComplete: () => {
+      gsap.set(socialsRef.current, { pointerEvents: 'auto' });
+    }});
+ 
   }, []);
 
   // Will run every time highlightedWord changes so that on-hover and 

--- a/components/ParticleGraphs.jsx
+++ b/components/ParticleGraphs.jsx
@@ -1,11 +1,11 @@
 import React, { useRef, useEffect, useMemo } from 'react';
 
 // Configuration constants
-const HIST_WIDTH = 180;
-const HIST_HEIGHT = 82; // 0.75 of previous 110 to create space for labels
+const HIST_WIDTH = 144; // 80% of 180
+const HIST_HEIGHT = 66; // scaled down proportionally
 const HIST_BINS = 14;
 
-const COLOR_SIZE = 82; // square canvas for colour ring
+const COLOR_SIZE = 66; // 80% of previous 82
 const COLOR_WIDTH = COLOR_SIZE;
 const COLOR_HEIGHT = COLOR_SIZE;
 
@@ -274,7 +274,7 @@ export default function ParticleGraphs({ particleData }) {
         />
         <span className="graph-label">y-pos {yRange && Number.isFinite(yRange.min) ? `(${yRange.min.toFixed(1)} → ${yRange.max.toFixed(1)})` : ''}</span>
       </div>
-      <div className="graph-wrapper">
+      <div className="graph-wrapper colour-graph">
         <canvas
           ref={colorCanvasRef}
           width={COLOR_WIDTH}

--- a/components/ParticleGraphs.jsx
+++ b/components/ParticleGraphs.jsx
@@ -1,0 +1,222 @@
+import React, { useRef, useEffect, useMemo } from 'react';
+
+// Configuration constants
+const HIST_WIDTH = 180;
+const HIST_HEIGHT = 82; // 0.75 of previous 110 to create space for labels
+const HIST_BINS = 14;
+
+const COLOR_WIDTH = 180;
+const COLOR_HEIGHT = 82;
+
+// Utility to convert RGB to Hue (0-360)
+function rgbToHue(r, g, b) {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  if (delta === 0) return 0;
+  let hue;
+  if (max === r) hue = ((g - b) / delta) % 6;
+  else if (max === g) hue = (b - r) / delta + 2;
+  else hue = (r - g) / delta + 4;
+  hue = (hue * 60 + 360) % 360;
+  return hue;
+}
+
+export default function ParticleGraphs({ particleData }) {
+  const histCanvasRef = useRef(null);
+  const colorCanvasRef = useRef(null);
+  const peaksRef = useRef(new Array(HIST_BINS).fill(0)); // Persistent peak heights per bin
+
+  // Process data – memoised for perf
+  const { yHistogram, colorBins, yRange, stats } = useMemo(() => {
+    if (!particleData?.positions || !particleData?.colors) {
+      return { yHistogram: [], colorBins: {}, yRange: null, stats: null };
+    }
+
+    const positions = particleData.positions;
+    const colors = particleData.colors;
+
+    // --------- Build Y-position histogram (positive & negative) ---------
+    const sampleRate = 3; // every 3rd particle for perf
+    const yValues = [];
+    for (let i = 1; i < positions.length; i += 3 * sampleRate) {
+      yValues.push(positions[i + 1]); // Y at i+1
+    }
+    if (yValues.length === 0) return { yHistogram: [], colorBins: {}, yRange: null, stats: null };
+
+    // Build full-range histogram (-max to +max) evenly across bins and gather stats
+    const yMin = Math.min(...yValues);
+    const yMax = Math.max(...yValues);
+    const binSize = (yMax - yMin) / HIST_BINS;
+    const fullHist = new Array(HIST_BINS).fill(0);
+
+    // Stats for normal overlay
+    let sumY = 0;
+    let sumY2 = 0;
+
+    yValues.forEach((v) => {
+      const idx = Math.min(Math.floor((v - yMin) / binSize), HIST_BINS - 1);
+      fullHist[idx]++;
+
+      sumY += v;
+      sumY2 += v * v;
+    });
+
+    const n = yValues.length;
+    const mean = sumY / n;
+    const variance = Math.max(sumY2 / n - mean * mean, 1e-6);
+    const sigma = Math.sqrt(variance);
+
+    // --------- Build colour distribution ---------
+    const colourBins = {
+      red: 0, orange: 0, yellow: 0, green: 0,
+      cyan: 0, blue: 0, purple: 0, magenta: 0,
+    };
+    const colourSampleRate = 3;
+    for (let i = 0; i < colors.length; i += 3 * colourSampleRate) {
+      const r = colors[i];
+      const g = colors[i + 1];
+      const b = colors[i + 2];
+      const h = rgbToHue(r, g, b);
+      if (h < 30 || h >= 330) colourBins.red++;
+      else if (h < 60) colourBins.orange++;
+      else if (h < 90) colourBins.yellow++;
+      else if (h < 150) colourBins.green++;
+      else if (h < 180) colourBins.cyan++;
+      else if (h < 240) colourBins.blue++;
+      else if (h < 300) colourBins.purple++;
+      else colourBins.magenta++;
+    }
+
+    return { yHistogram: fullHist, colorBins: colourBins, yRange: { min: yMin, max: yMax }, stats: { mean, sigma } };
+  }, [particleData]);
+
+  // Draw Cyber-punk Histogram with falling peak indicators
+  useEffect(() => {
+    const canvas = histCanvasRef.current;
+    if (!canvas || !yHistogram) return;
+    const ctx = canvas.getContext('2d');
+
+    ctx.globalAlpha = 0.8; // overall transparency
+
+    const hist = yHistogram || [];
+    const maxCount = Math.max(...hist, 1);
+
+    const barWidth = HIST_WIDTH / HIST_BINS;
+    const baseY = HIST_HEIGHT - 4; // padding bottom
+    const maxBarHeight = HIST_HEIGHT - 18; // leave head-room for peaks
+
+    // Slightly clear previous frame to create soft trail
+    ctx.fillStyle = 'rgba(0,0,0,0.18)';
+    ctx.fillRect(0, 0, HIST_WIDTH, HIST_HEIGHT);
+
+    // Subtle glow in cotton-candy palette
+    ctx.shadowBlur = 2;
+    ctx.shadowColor = 'rgba(216,180,254,0.25)';
+
+    const peaks = peaksRef.current;
+    const PEAK_DECAY = 0.8; // pixels per frame
+
+    for (let i = 0; i < HIST_BINS; i++) {
+      let barHeight = (hist[i] / maxCount) * maxBarHeight;
+      if (!Number.isFinite(barHeight)) barHeight = 0;
+
+      // Update peak height
+      if (barHeight > (peaks[i] || 0)) {
+        peaks[i] = barHeight;
+      } else {
+        peaks[i] = Math.max((peaks[i] || 0) - PEAK_DECAY, barHeight);
+      }
+
+      // Draw bar using cotton-candy gradient (lavender → pink)
+      const grad = ctx.createLinearGradient(0, baseY - barHeight, 0, baseY);
+      grad.addColorStop(0, '#818cf8');   // top – indigo-lavender
+      grad.addColorStop(0.7, '#d8b4fe'); // mid – light purple
+      grad.addColorStop(1, '#f9a8d4');   // bottom – soft pink
+      ctx.fillStyle = grad;
+      ctx.fillRect(i * barWidth, baseY - barHeight, barWidth - 2, barHeight);
+
+      // Draw peak indicator (lavender highlight 2 px)
+      ctx.fillStyle = '#d8b4fe';
+      ctx.fillRect(i * barWidth, baseY - peaks[i] - 2, barWidth - 2, 2);
+    }
+
+    // ---- Draw normal distribution line ----
+    if (stats && stats.sigma > 0.0001) {
+      const { mean, sigma } = stats;
+      ctx.beginPath();
+      ctx.strokeStyle = '#5ffbf1';
+      ctx.lineWidth = 1;
+
+      for (let i = 0; i < HIST_BINS; i++) {
+        // bin center value
+        const yVal = ((i + 0.5) * (yRange.max - yRange.min)) / HIST_BINS + yRange.min;
+        const z = (yVal - mean) / sigma;
+        const pdf = Math.exp(-0.5 * z * z);
+        const pdfHeight = pdf * maxBarHeight; // scaled so peak aligns with maxBarHeight
+        const x = i * barWidth + barWidth / 2;
+        const y = baseY - pdfHeight;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+
+    ctx.shadowBlur = 0; // reset
+
+    ctx.globalAlpha = 1; // restore for subsequent operations
+
+  }, [yHistogram, stats, yRange]);
+
+  // Draw Colour distribution
+  useEffect(() => {
+    const canvas = colorCanvasRef.current;
+    if (!canvas || !colorBins || Object.keys(colorBins).length === 0) return;
+    const ctx = canvas.getContext('2d');
+    ctx.globalAlpha = 0.8;
+    ctx.clearRect(0, 0, COLOR_WIDTH, COLOR_HEIGHT);
+
+    const categories = Object.keys(colorBins);
+    const values = Object.values(colorBins);
+    const maxCount = Math.max(...values);
+    const barWidth = COLOR_WIDTH / categories.length;
+
+    const colourMap = {
+      red: '#f87171', orange: '#fb923c', yellow: '#fde047', green: '#4ade80',
+      cyan: '#22d3ee', blue: '#60a5fa', purple: '#a78bfa', magenta: '#f472b6',
+    };
+
+    categories.forEach((cat, i) => {
+      const barHeight = maxCount ? (values[i] / maxCount) * COLOR_HEIGHT : 0;
+      ctx.fillStyle = colourMap[cat] || '#fff';
+      ctx.fillRect(i * barWidth, COLOR_HEIGHT - barHeight, barWidth - 1, barHeight);
+    });
+
+    ctx.globalAlpha = 1;
+  }, [colorBins]);
+
+  return (
+    <div className="graphs-boxes">
+      <div className="graph-wrapper">
+        <canvas
+          ref={histCanvasRef}
+          width={HIST_WIDTH}
+          height={HIST_HEIGHT}
+          className="graph-canvas"
+          aria-label="Y Position Distribution"
+        />
+        <span className="graph-label">y-pos {yRange && Number.isFinite(yRange.min) ? `(${yRange.min.toFixed(1)} → ${yRange.max.toFixed(1)})` : ''}</span>
+      </div>
+      <div className="graph-wrapper">
+        <canvas
+          ref={colorCanvasRef}
+          width={COLOR_WIDTH}
+          height={COLOR_HEIGHT}
+          className="graph-canvas"
+          aria-label="Colour Distribution"
+        />
+        <span className="graph-label">colour-dsn</span>
+      </div>
+    </div>
+  );
+} 

--- a/components/ParticleGraphs.jsx
+++ b/components/ParticleGraphs.jsx
@@ -264,7 +264,7 @@ export default function ParticleGraphs({ particleData }) {
 
   return (
     <div className="graphs-boxes">
-      <div className="graph-wrapper">
+      <div className="graph-wrapper y-graph">
         <canvas
           ref={histCanvasRef}
           width={HIST_WIDTH}

--- a/components/assets/DownArrow.jsx
+++ b/components/assets/DownArrow.jsx
@@ -28,7 +28,7 @@ function DownArrow(props) {
       { 
         opacity: 1, 
         duration: 3, 
-        delay: 5, 
+        delay: 3, 
         ease: "power1.inOut",
         onComplete: function() {
           gsap.set(downArrowRef.current, { pointerEvents: "auto" })

--- a/components/assets/JustBlackjackLogo.jsx
+++ b/components/assets/JustBlackjackLogo.jsx
@@ -23,7 +23,7 @@ const JustBlackjackLogo = ({ ...props }) => {
             { 
                 opacity: 1, 
                 duration: 3, 
-                delay: 5, 
+                delay: 3, 
                 ease: "power1.inOut",
                 onComplete: function() {
                 gsap.set(jBButtonRef.current, { pointerEvents: "auto" })

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Landing from '../components/Landing';
 import Content from '../components/Content';
 import RippleScene from '../components/threejs/LandingScene';
-import { useEffect } from 'react';
 import gsap from 'gsap';
 import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
 
 gsap.registerPlugin(ScrollTrigger);
 
 export default function Home() {
+  // Shared particle data state
+  const [particleData, setParticleData] = useState(null);
 
   useEffect(() => {
     gsap.fromTo(
@@ -63,9 +64,10 @@ export default function Home() {
         style={{
           height: '100vh', width: '100vw', position: 'fixed', zIndex: -10,
         }}
+        onParticleDataUpdate={(data)=>setParticleData(data)}
       />
 
-      <Landing />
+      <Landing particleData={particleData} />
       
       <Content />
     </div>

--- a/styles/Graphs.scss
+++ b/styles/Graphs.scss
@@ -50,4 +50,19 @@
     width: 50px;
     height: 50px;
   }
+
+  /* place graphs directly below title (default absolute positioning) */
+  .graphs-boxes {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 0.5rem;
+  }
+
+  .y-graph { margin-left: 0; }
+
+  .y-graph .graph-canvas {
+    width: 90px;
+    height: 45px;
+  }
 } 

--- a/styles/Graphs.scss
+++ b/styles/Graphs.scss
@@ -1,0 +1,36 @@
+.graphs-boxes {
+  display: flex;
+  gap: 1rem;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 0.5rem;
+}
+
+.graph-canvas {
+  border-radius: 0; /* square edges */
+  background: rgba(0,0,0,0.05); /* more transparent */
+  width: 160px;
+  height: 80px; // reduced height
+}
+
+.graph-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.graph-label {
+  margin-top: 0.25rem;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.8);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+@media screen and (max-width: 640px) {
+  .graph-canvas {
+    width: 130px;
+    height: 60px;
+  }
+} 

--- a/styles/Graphs.scss
+++ b/styles/Graphs.scss
@@ -14,6 +14,12 @@
   height: 80px; // reduced height
 }
 
+// narrower square canvas for colour ring
+.color-ring {
+  width: 80px;
+  height: 80px;
+}
+
 .graph-wrapper {
   display: flex;
   flex-direction: column;
@@ -31,6 +37,10 @@
 @media screen and (max-width: 640px) {
   .graph-canvas {
     width: 130px;
+    height: 60px;
+  }
+  .color-ring {
+    width: 60px;
     height: 60px;
   }
 } 

--- a/styles/Graphs.scss
+++ b/styles/Graphs.scss
@@ -10,14 +10,14 @@
 .graph-canvas {
   border-radius: 0; /* square edges */
   background: rgba(0,0,0,0.05); /* more transparent */
-  width: 160px;
-  height: 80px; // reduced height
+  width: 128px; /* 80% */
+  height: 64px;
 }
 
 // narrower square canvas for colour ring
 .color-ring {
-  width: 80px;
-  height: 80px;
+  width: 64px;
+  height: 64px;
 }
 
 .graph-wrapper {
@@ -29,18 +29,25 @@
 .graph-label {
   margin-top: 0.25rem;
   font-size: 0.65rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(255, 255, 255, 0.6); // greyer
   text-transform: lowercase;
   letter-spacing: 0.02em;
 }
 
+// Hide colour graph on small screens
+@media screen and (max-width: 640px) {
+  .colour-graph {
+    display: none;
+  }
+}
+
 @media screen and (max-width: 640px) {
   .graph-canvas {
-    width: 130px;
-    height: 60px;
+    width: 100px;
+    height: 50px;
   }
   .color-ring {
-    width: 60px;
-    height: 60px;
+    width: 50px;
+    height: 50px;
   }
 } 

--- a/styles/Landing.scss
+++ b/styles/Landing.scss
@@ -58,6 +58,13 @@
     justify-content: space-between;
 }
 
+.title-left {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    position: relative;
+}
+
 .title-text {
     font-size: 7rem;
     max-width: 870px;

--- a/styles/Landing.scss
+++ b/styles/Landing.scss
@@ -132,6 +132,18 @@
         flex-direction: column;
     }
 
+    /* revert order */
+    .landing-link-container {
+        order: 2;
+        margin-top: 0.5rem; /* tighter gap below histogram */
+    }
+
+    .title-left {
+        order: 1;
+        flex-direction: column; /* stack histogram under heading */
+        align-items: flex-start;
+    }
+
     .title-container {
         flex-direction: column;
         margin-top: 1rem;
@@ -143,12 +155,20 @@
 
     .title-text {
         font-size: 5rem;
-        padding-bottom: 2rem;
+        padding-bottom: 1.25rem; /* reduce space below name */
     }
 
     .justblackjack-button {
         right: 7.5%;
     }
+
+    .graphs-boxes {
+        position: static;
+        margin-left: auto;
+        display: flex;
+    }
+
+    .y-graph { margin-left: auto; }
 
 }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -2,7 +2,6 @@
 @import "./Content.scss";
 @import "./JustBlackjack.scss";
 @import "./Timeline.scss";
-@import "./ParticleStats.scss";
 @import "./Graphs.scss";
 
 html,

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -2,6 +2,8 @@
 @import "./Content.scss";
 @import "./JustBlackjack.scss";
 @import "./Timeline.scss";
+@import "./ParticleStats.scss";
+@import "./Graphs.scss";
 
 html,
 body {


### PR DESCRIPTION
# Header polish & responsive particle graphs  
Merge `feature/landing-scene-upgrades` → `feature/about-me`

![CleanShot 2025-07-04 at 23 55 28](https://github.com/user-attachments/assets/390507d2-0cca-4977-9be5-32e192343f45)
![CleanShot 2025-07-04 at 23 55 42](https://github.com/user-attachments/assets/0f4e4c25-1a2f-470f-9a5e-b85067082e9a)


## ✨  What’s new
1. **Live particle graphs under the hero name**  
   * Cyber-punk histogram of Y-positions (with peak indicators & mint normal-distribution overlay).  
   * Optional colour spectrum ring (hidden on ≤640 px for performance/space).
2. **Mobile layout refinements**  
   * Histogram now stacks directly below “Darren Wong”.  
   * Tighter vertical spacing between name, graphs, and socials so the roles never overlap the particle field.
3. **Styling tweaks**  
   * Cotton-candy palette across bars; square canvas corners; lighter graph backgrounds.  
   * Roles & socials fade in simultaneously; arrow/logo delays trimmed.
4. **File cleanup**  
   * Removed obsolete `ParticleStats` overlay (component + SCSS).  
   * Added / updated `styles/Graphs.scss`, `styles/Landing.scss`, and `components/ParticleGraphs.jsx`.